### PR TITLE
Fix The Android Build Error And The iOS Crash On The Launch

### DIFF
--- a/blaze_flutter_sdk/android/src/main/kotlin/com/blaze/flutterblazesdk/shared/BlazeAsyncBridgeModule.kt
+++ b/blaze_flutter_sdk/android/src/main/kotlin/com/blaze/flutterblazesdk/shared/BlazeAsyncBridgeModule.kt
@@ -69,8 +69,9 @@ interface BlazeAsyncBridge {
     }
 }
 
-/// Private empty parameters data class for methods with no parameters.
-private object EmptyParams
+/// Empty parameters data class for methods with no parameters.
+@PublishedApi
+internal object EmptyParams
 
 /**
  * Call a Dart method with parameters and return the result as type T.

--- a/blaze_flutter_sdk/ios/Sources/Utils/BlazeFlutterSDKHelper.swift
+++ b/blaze_flutter_sdk/ios/Sources/Utils/BlazeFlutterSDKHelper.swift
@@ -11,7 +11,7 @@ import BlazeSDK
 class BlazeFlutterSDKHelper: BlazeFlutterSDKHelperProtocol {
     
     lazy var flutterSDKVersion: String? = {
-        let infoDict = Bundle.blazeFlutter.infoDictionary
+        let infoDict = Bundle.blazeFlutter?.infoDictionary
         let flutterVersionName = infoDict?["CFBundleShortVersionString"] as? String
         return flutterVersionName
     }()
@@ -21,11 +21,10 @@ class BlazeFlutterSDKHelper: BlazeFlutterSDKHelperProtocol {
 extension Foundation.Bundle {
     
     /// Since BlazeSDK is a framework, the bundle for classes within this module can be used directly.
-    static let blazeFlutter: Bundle = {
-        let bundleRelativePath = Bundle.main.path(forResource: "blaze-flutter-sdk-bundle",
-                                                  ofType: "bundle")!
-        let bundle = Bundle(path: bundleRelativePath)!
-        return bundle
+    static let blazeFlutter: Bundle? = {
+        Bundle.main
+            .path(forResource: "blaze-flutter-sdk-bundle", ofType: "bundle")
+            .flatMap(Bundle.init(path:))
     }()
     
 }


### PR DESCRIPTION
## The Scope

This summarizes two crash/visibility issues in the iOS and Android layers of the SDK and proposes minimal, backward-compatible fixes.

## iOS

In some cases, the module bundle is `nil` when the SDK attempts to access it, which triggers a crash due to force-unwrapping:

**The crash:**   
> blaze\_flutter\_sdk/BlazeFlutterSDKHelper.swift:26: Fatal error: Unexpectedly found nil while unwrapping an Optional value

The exact reproduction conditions are unclear. On the same Mac and environment, two empty Flutter projects behave differently: one launches without errors, while the other crashes at startup.

### The Solution

Remove the force unwrap. Make `blazeFlutter` optional and handle its use safely at all call sites

## Android

Because `callDartMethodInternal` is effectively public (`@PublishedApi`), an inline call cannot reference the private `EmptyParams` type:

**The crash:**   
> Public-API inline function cannot access non-public-API 'private object EmptyParams defined in com.blaze.flutterblazesdk.shared in file BlazeAsyncBridgeModule.kt

### The Solution

Given there’s no meaningful security risk, the simplest fix is to make `EmptyParams` public (or otherwise visible to the inlined caller).

---

## Effect on Older SDK Clients

Since `flutterSDKVersion` is already optional, making `blazeFlutter` optional is safe. Existing clients can adopt these changes without code modifications.

Making `EmptyParams` public should likewise have no observable impact on existing users.

## Effect on `blaze_flutter_gam_ads` and `blaze_flutter_ima_ads`

We don’t currently use these dependencies. The effect of these changes on these two packages remains untested.

## Environment

* Kotlin: 2.2.0, Gradle: 8.14.3
* Swift: 6.0.3, iOS 14.1+
* Flutter: 3.27.2, Dart: 3.6.1, DevTools 2.40.2
* macOS: 15.6 (Apple M1 Pro)
